### PR TITLE
Bump spring boot version to 2.6.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.6.0</version>
+        <version>2.6.1</version>
     </parent>
 
     <dependencies>
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-security</artifactId>
-            <version>2.6.0</version>
+            <version>2.6.1</version>
         </dependency>
 
         <dependency>
@@ -89,7 +89,7 @@
         <dependency>
             <groupId>org.modelmapper</groupId>
             <artifactId>modelmapper</artifactId>
-            <version>2.4.4</version>
+            <version>2.4.5</version>
         </dependency>
 
         <dependency>
@@ -106,14 +106,14 @@
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>mockwebserver</artifactId>
-            <version>4.9.2</version>
+            <version>4.9.3</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
-            <version>4.9.2</version>
+            <version>4.9.3</version>
         </dependency>
         <dependency>
             <groupId>javax.validation</groupId>
@@ -128,7 +128,7 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <version>2.6.0</version>
+                <version>2.6.1</version>
                 <configuration>
                     <fork>true</fork>
                     <executable>true</executable>


### PR DESCRIPTION
## Description

Spring Boot has a new Stable release version: 2.6.1.
There's no breaking changes in this update for our project, and has fixed a lot of bugs, so suggest upgrade to this new version.

See the [Release Note](https://github.com/spring-projects/spring-boot/releases/tag/v2.6.1) for more details.