### PR TITLE
Bump spring boot version to 2.6.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.6.1</version>
+        <version>2.6.2</version>
     </parent>
 
     <dependencies>
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-security</artifactId>
-            <version>2.6.1</version>
+            <version>2.6.2</version>
         </dependency>
 
         <dependency>
@@ -136,19 +136,19 @@
         <dependency>
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
-            <version>20210307</version>
+            <version>20211205</version>
         </dependency>
 
         <dependency>
             <groupId>com.konghq</groupId>
             <artifactId>unirest-java</artifactId>
-            <version>3.13.3</version>
+            <version>3.13.4</version>
         </dependency>
 
         <dependency>
             <groupId>com.konghq</groupId>
             <artifactId>unirest-java</artifactId>
-            <version>3.13.3</version>
+            <version>3.13.4</version>
             <classifier>standalone</classifier>
         </dependency>
 
@@ -159,7 +159,7 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <version>2.6.1</version>
+                <version>2.6.2</version>
                 <configuration>
                     <fork>true</fork>
                     <executable>true</executable>


### PR DESCRIPTION
## Description
Spring boot has a new stable release version: `2.6.2`, and there's no breaking changes for our proj.
See the [Release Notes](https://github.com/spring-projects/spring-boot/releases/tag/v2.6.2) for more details.

## How to verify?
Run proj, make sure it starts normally.