### PR TITLE
Fix: Prevent getting issues/pull requests from GitHub failed

### DIFF
--- a/src/main/java/pvs/app/controller/GithubApiController.java
+++ b/src/main/java/pvs/app/controller/GithubApiController.java
@@ -121,9 +121,15 @@ public class GithubApiController {
 
         try {
             githubIssueDTOs = githubApiService.getIssuesFromGithub(repoOwner, repoName);
-            if (null == githubIssueDTOs) {
+
+            // Retry one time if the githubIssueDTOs is null
+            for (int retryCount = 1; retryCount <= 1; retryCount++){
+                if (githubIssueDTOs != null) break;
+                githubIssueDTOs = githubApiService.getIssuesFromGithub(repoOwner, repoName);
+            }
+            if (githubIssueDTOs == null) {
                 return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                        .body("cannot get issue data");
+                        .body("Get issue data failed from GitHub api");
             }
         } catch (InterruptedException | IOException e) {
             logger.debug(e.getMessage());
@@ -153,8 +159,15 @@ public class GithubApiController {
 
         try {
             githubPullRequestDTOs = githubApiService.getPullRequestMetricsFromGithub(repoOwner, repoName);
-            if (githubPullRequestDTOs.isEmpty()) {
-                return ResponseEntity.status(HttpStatus.OK).body(null);
+
+            // Retry one time if the githubPullRequestDTOs is null
+            for (int retryCount = 1; retryCount <= 1; retryCount++){
+                if (githubPullRequestDTOs != null) break;
+                githubPullRequestDTOs = githubApiService.getPullRequestMetricsFromGithub(repoOwner, repoName);
+            }
+            if (githubPullRequestDTOs == null) {
+                return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                        .body("Get pull request data failed from GitHub api");
             }
         } catch (InterruptedException | IOException e) {
             logger.debug(e.getMessage());

--- a/src/main/java/pvs/app/controller/GithubApiController.java
+++ b/src/main/java/pvs/app/controller/GithubApiController.java
@@ -117,16 +117,14 @@ public class GithubApiController {
     public ResponseEntity<String> getIssues(@PathVariable("repoOwner") String repoOwner, @PathVariable("repoName") String repoName) {
         ObjectMapper objectMapper = new ObjectMapper();
 
-        List<GithubIssueDTO> githubIssueDTOs;
+        List<GithubIssueDTO> githubIssueDTOs = null;
 
         try {
-            githubIssueDTOs = githubApiService.getIssuesFromGithub(repoOwner, repoName);
-
             // Retry if the githubIssueDTOs is null
-            int retryCount = 1;
+            int retryCount = 0;
             while (retryCount <= 5) {
-                if (githubIssueDTOs != null) break;
                 githubIssueDTOs = githubApiService.getIssuesFromGithub(repoOwner, repoName);
+                if (githubIssueDTOs != null) break;
                 retryCount++;
             }
 
@@ -158,16 +156,14 @@ public class GithubApiController {
     public ResponseEntity<String> getPullRequests(@PathVariable("repoOwner") String repoOwner, @PathVariable("repoName") String repoName) {
         ObjectMapper objectMapper = new ObjectMapper();
 
-        List<GithubPullRequestDTO> githubPullRequestDTOs;
+        List<GithubPullRequestDTO> githubPullRequestDTOs = null;
 
         try {
-            githubPullRequestDTOs = githubApiService.getPullRequestMetricsFromGithub(repoOwner, repoName);
-
             // Retry if the githubPullRequestDTOs is null
-            int retryCount = 1;
+            int retryCount = 0;
             while (retryCount <= 5) {
-                if (githubPullRequestDTOs != null) break;
                 githubPullRequestDTOs = githubApiService.getPullRequestMetricsFromGithub(repoOwner, repoName);
+                if (githubPullRequestDTOs != null) break;
                 retryCount++;
             }
 

--- a/src/main/java/pvs/app/controller/GithubApiController.java
+++ b/src/main/java/pvs/app/controller/GithubApiController.java
@@ -122,14 +122,17 @@ public class GithubApiController {
         try {
             githubIssueDTOs = githubApiService.getIssuesFromGithub(repoOwner, repoName);
 
-            // Retry one time if the githubIssueDTOs is null
-            for (int retryCount = 1; retryCount <= 1; retryCount++){
+            // Retry if the githubIssueDTOs is null
+            int retryCount = 1;
+            while (retryCount <= 5) {
                 if (githubIssueDTOs != null) break;
                 githubIssueDTOs = githubApiService.getIssuesFromGithub(repoOwner, repoName);
+                retryCount++;
             }
+
             if (githubIssueDTOs == null) {
                 return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                        .body("Get issue data failed from GitHub api");
+                        .body("Get issue data failed from GitHub API");
             }
         } catch (InterruptedException | IOException e) {
             logger.debug(e.getMessage());
@@ -160,14 +163,17 @@ public class GithubApiController {
         try {
             githubPullRequestDTOs = githubApiService.getPullRequestMetricsFromGithub(repoOwner, repoName);
 
-            // Retry one time if the githubPullRequestDTOs is null
-            for (int retryCount = 1; retryCount <= 1; retryCount++){
+            // Retry if the githubPullRequestDTOs is null
+            int retryCount = 1;
+            while (retryCount <= 5) {
                 if (githubPullRequestDTOs != null) break;
                 githubPullRequestDTOs = githubApiService.getPullRequestMetricsFromGithub(repoOwner, repoName);
+                retryCount++;
             }
+
             if (githubPullRequestDTOs == null) {
                 return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                        .body("Get pull request data failed from GitHub api");
+                        .body("Get pull request data failed from GitHub API");
             }
         } catch (InterruptedException | IOException e) {
             logger.debug(e.getMessage());


### PR DESCRIPTION
# Description

Sometimes when the GitHub API is called, it will return null because of some unknown reasons.
Especially the issues and pull requests, both kinds of data get from GitHub and send it to the frontend directly instead of storing in database.
To avoid this situation, i make the functions of getting issues/pull requests execute again when the results are null.